### PR TITLE
Add support for custom list callouts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { EditorView } from "@codemirror/view";
 import { debounce, Events, MarkdownView, Plugin } from "obsidian";
 import escapeStringRegexp from "escape-string-regexp";
 import {
+  Callout,
   CalloutConfig,
   ListCalloutSettings,
   ListCalloutsSettings,
@@ -102,11 +103,15 @@ export default class ListCalloutsPlugin extends Plugin {
   }
 
   async loadSettings() {
-    const loadedSettings = await this.loadData();
+    const loadedSettings = await this.loadData() as Callout[];
+    const customCallouts = loadedSettings.filter(callout => callout.custom === true);
+    const modifiedBuiltins = loadedSettings.filter(callout => callout.custom !== true);
 
     this.settings = DEFAULT_SETTINGS.map((s, i) => {
-      return Object.assign({}, s, loadedSettings ? loadedSettings[i] : {});
+      return Object.assign({}, s, loadedSettings ? modifiedBuiltins[i] : {});
     });
+
+    this.settings.push(...customCallouts);
   }
 
   async saveSettings() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 import {
   ButtonComponent,
+  ColorComponent,
   Menu,
   PluginSettingTab,
   setIcon,
@@ -44,6 +45,7 @@ export interface Callout {
   char: string;
   color: string;
   icon?: string;
+  custom?: boolean;
 }
 
 export interface CalloutConfig extends Callout {
@@ -95,11 +97,46 @@ export function buildSettingCallout(root: HTMLElement, callout: Callout) {
   );
 }
 
+function attachIconMenu(
+  btn: ButtonComponent,
+  onSelect: (icon: null | string) => void
+) {
+  btn.onClick((e) => {
+    const menu = new Menu().setUseNativeMenu(false);
+
+    (menu as any).dom?.addClass("lc-menu");
+
+    menu.addItem((item) => {
+      item.setTitle("No icon");
+      item.onClick(() => {
+        btn.buttonEl.empty();
+        btn.setButtonText("Set Icon");
+        onSelect(null);
+      });
+    });
+
+    // Menu
+    iconOptions.forEach((icon) => {
+      menu.addItem((item) => {
+        item.setIcon(icon);
+        item.onClick(() => {
+          btn.buttonEl.empty();
+          btn.setIcon(icon);
+          onSelect(icon);
+        });
+      });
+    });
+
+    menu.showAtMouseEvent(e);
+  });
+}
+
 export function buildSetting(
   containerEl: HTMLElement,
   plugin: ListCalloutsPlugin,
   index: number,
-  callout: Callout
+  callout: Callout,
+  onDelete: (index: number) => void,
 ) {
   containerEl.createDiv({ cls: "lc-setting" }, (el) => {
     const calloutContainer = el.createDiv({ cls: "lc-callout-container" });
@@ -127,48 +164,123 @@ export function buildSetting(
           btn.setButtonText("Set Icon");
         }
 
-        // Button
-        btn.onClick((e) => {
-          const menu = new Menu().setUseNativeMenu(false);
+        attachIconMenu(btn, (icon) => {
+          if (icon == null) {
+            delete plugin.settings[index].icon;
+          } else {
+            plugin.settings[index].icon = icon;
+          }
 
-          (menu as any).dom?.addClass("lc-menu");
-
-          menu.addItem((item) => {
-            item.setTitle("No icon");
-            item.onClick(() => {
-              delete plugin.settings[index].icon;
-
-              plugin.saveSettings();
-
-              buildSettingCallout(calloutContainer, plugin.settings[index]);
-
-              btn.buttonEl.empty();
-              btn.setButtonText("Set Icon");
-            });
-          });
-
-          // Menu
-          iconOptions.forEach((icon) => {
-            menu.addItem((item) => {
-              item.setIcon(icon);
-              item.onClick(() => {
-                plugin.settings[index].icon = icon;
-
-                plugin.saveSettings();
-
-                buildSettingCallout(calloutContainer, plugin.settings[index]);
-
-                btn.buttonEl.empty();
-                btn.setIcon(icon);
-              });
-            });
-          });
-
-          menu.showAtMouseEvent(e);
-        });
+          plugin.saveSettings();
+          buildSettingCallout(calloutContainer, plugin.settings[index]);
+        })
       });
+
+      // Color selection.
+      if (callout.custom) {
+        const [r, g, b] = callout.color
+          .split(",")
+          .map(v => parseInt(v.trim(), 10));
+
+        const color = new ColorComponent(inputContainer)
+          .setValueRgb({r, g, b})
+          .onChange((_value) => {
+            const {r, g, b} = color.getValueRgb();
+            plugin.settings[index].color = `${r}, ${g}, ${b}`;
+
+            plugin.saveSettings();
+            buildSettingCallout(calloutContainer, plugin.settings[index]);
+          });
+      }
+
+      // Delete button.
+      if (callout.custom) {
+        const rightAlign = inputContainer.createDiv({ cls: "lc-input-right-align" });
+        new ButtonComponent(rightAlign)
+          .setButtonText("Delete")
+          .setWarning()
+          .onClick((_e) => {
+            onDelete(index);
+          });
+      }
     });
   });
+}
+
+function buildNewCalloutSetting(
+  containerEl: HTMLElement,
+  plugin: ListCalloutsPlugin,
+  onSubmit: (callout: Callout) => void
+) {
+  const callout: Callout = {
+    char: "",
+    color: "127, 127, 127",
+    icon: null,
+    custom: true,
+  };
+
+  containerEl.createDiv({ cls: "lc-setting" }, (settingContainer) => {
+    settingContainer.createDiv({ cls: "setting-item-name" }, (e) => e.setText("Create a new Callout"));
+    settingContainer.createDiv({ cls: "setting-item-description" }, (e) => e.setText("Create additional list callout styles."));
+
+    // Preview.
+    const calloutContainer = settingContainer.createDiv({ cls: "lc-callout-container" });
+
+    // Callout character.
+    const inputContainer = settingContainer.createDiv({ cls: "lc-input-container" });
+
+    const char = new TextComponent(inputContainer)
+      .setValue("")
+      .setPlaceholder("...")
+      .onChange((value) => {
+        callout.char = value;
+        redraw();
+      });
+
+    // Callout icon.
+    const icon = new ButtonComponent(inputContainer)
+      .setButtonText("Set Icon");
+
+    attachIconMenu(icon, (icon) => {
+      if (icon == null) {
+        delete callout.icon;
+      } else {
+        callout.icon = icon;
+      }
+      redraw();
+    });
+
+    // Callout color.
+    const color = new ColorComponent(inputContainer)
+      .setValueRgb({r: 127, g: 127, b: 127})
+      .onChange((_value) => {
+        const {r, g, b} = color.getValueRgb();
+        callout.color = `${r}, ${g}, ${b}`;
+        redraw();
+      });
+
+    // Create button.
+    const rightAlign = inputContainer.createDiv({ cls: "lc-input-right-align" });
+    const submit = new ButtonComponent(rightAlign)
+      .setButtonText("Create")
+      .setDisabled(true)
+      .onClick(() => {
+        onSubmit(callout);
+      });
+
+    // Redraw callout/settings.
+    function redraw() {
+      buildSettingCallout(calloutContainer, callout);
+
+      const hasNoCharacter = callout.char.length === 0;
+      const hasConflictingCharacter = plugin.settings.find((c) => c.char === char.getValue()) !== undefined;
+
+      submit.setDisabled(hasNoCharacter || hasConflictingCharacter);
+    }
+
+    redraw();
+  });
+
 }
 
 export class ListCalloutSettings extends PluginSettingTab {
@@ -199,7 +311,21 @@ export class ListCalloutSettings extends PluginSettingTab {
     );
 
     this.plugin.settings.forEach((callout, index) => {
-      buildSetting(containerEl, this.plugin, index, callout);
+      buildSetting(containerEl, this.plugin, index, callout, (indexToDelete) => {
+        this.plugin.settings.splice(indexToDelete, 1);
+        this.plugin.saveSettings();
+
+        // Re-draw.
+        this.display();
+      });
+    });
+
+    buildNewCalloutSetting(containerEl, this.plugin, (callout) => {
+      this.plugin.settings.push(callout);
+      this.plugin.saveSettings();
+
+      // Re-draw.
+      this.display();
     });
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -183,9 +183,13 @@ settings:
   z-index: 0;
 }
 
+.lc-setting input,
+.lc-setting .lc-input-container > button {
+  margin-right: 10px;
+}
+
 .lc-setting input {
   width: 4em;
-  margin-right: 10px;
 }
 
 .lc-callout-container {
@@ -197,6 +201,11 @@ settings:
 .lc-input-container {
   display: flex;
   align-items: center;
+}
+
+.lc-input-right-align {
+  flex-grow: 1;
+  text-align: right;
 }
 
 .lc-menu .menu-item-icon,


### PR DESCRIPTION
Including a modified settings GUI for them.

- Added a section at the bottom of the settings for creating a new callout.
- Can delete custom callouts from settings.
- Can change the color of custom callouts from settings.

I did a tiny bit of refactoring of how settings are built to make it easier to reuse code between the existing `buildSetting` and the new section for creating a custom callout.