### PR TITLE
Fix reading mode and preview mode background width inconsistencies

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -100,7 +100,8 @@ settings:
   bottom: calc(-1 * var(--lc-bg-bottom));
   left: 0;
   display: block;
-  padding: inherit;
+  padding-top: inherit;
+  padding-bottom: inherit;
   z-index: -1;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -98,14 +98,10 @@ settings:
   top: calc(-1 * var(--lc-bg-top));
   right: calc(-1 * var(--lc-bg-right));
   bottom: calc(-1 * var(--lc-bg-bottom));
-  left: calc(-1 * var(--lc-bg-left));
+  left: 0;
   display: block;
   padding: inherit;
   z-index: -1;
-}
-
-.task-list-label ~ .lc-list-bg {
-  left: calc(-1 * var(--lc-bg-left-checkbox-lp));
 }
 
 .markdown-source-view:not(.is-live-preview) .cm-formatting-task ~ .lc-list-bg {
@@ -147,7 +143,7 @@ settings:
   top: calc(-1 * var(--lc-bg-top-reading) + 1px);
   right: calc(-1 * var(--lc-bg-right-reading) + 1px);
   bottom: calc(-1 * var(--lc-bg-bottom-reading) + 1px);
-  left: calc(-1 * var(--lc-bg-left-reading) + 1px);
+  left: calc(-1 * var(--list-indent));
   content: "";
   display: block;
   border-radius: 4px;


### PR DESCRIPTION
Before, in live preview:
![image](https://user-images.githubusercontent.com/3318117/214650408-4ada28d5-efb8-4651-b88b-1a7e1833841f.png)

Before, in reading mode:
![image](https://user-images.githubusercontent.com/3318117/214650500-b3789610-dede-434a-8a7d-b8df1d7cc542.png)

After, in live preview:
![image](https://user-images.githubusercontent.com/3318117/214651709-317b91fd-5024-4f23-a018-0178e14d6560.png)

After, in reading mode:
![image](https://user-images.githubusercontent.com/3318117/214651771-04784175-b471-4358-a655-fd6aeca232cd.png)
