### PR TITLE
Fix Callout Cursor Style and Click Behavior

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -120,6 +120,7 @@ settings:
   display: block;
   padding: inherit;
   z-index: -1;
+  cursor: text;
 }
 
 .task-list-label ~ .lc-list-bg {

--- a/styles.css
+++ b/styles.css
@@ -120,7 +120,7 @@ settings:
   display: block;
   padding: inherit;
   z-index: -1;
-  cursor: text;
+  pointer-events: none;
 }
 
 .task-list-label ~ .lc-list-bg {


### PR DESCRIPTION
The BG was resetting the cursor style to the default pointer, even though it is still clickable as a text area to move the cursor to that line. 

This changes the background so that clicks pass through it entirely.

This also fixes a minor issue where clicking on an already current callout would erroneously send it to the beginning of the line instead of the end.