### PR TITLE
Remove `build decos` log

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -158,7 +158,6 @@ export const calloutExtension = ViewPlugin.fromClass(
           tr.effects.some((e) => e.is(setConfig))
         )
       ) {
-        console.log('build decos');
         this.decorations = buildCalloutDecos(update.view, update.state);
       }
     }


### PR DESCRIPTION
With the recent 1.2.3 release, it appears a debugging statement was added to troubleshoot an issue (https://github.com/mgmeyers/obsidian-list-callouts/commit/c677dde1e1be22bff443ba508f1f935810a85010) but was not removed for final release.

_DevTools Console_
![image](https://github.com/mgmeyers/obsidian-list-callouts/assets/1379248/2e360f7d-977e-4ea2-905d-4555bf81cd62)
