### PR TITLE
Adds data-type attributes to list-callouts to allow custom styling

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,11 +59,12 @@ export class CalloutMarker extends WidgetType {
   }
 }
 
-export const calloutDecoration = (color: string) =>
+export const calloutDecoration = (char: string, color: string) =>
   Decoration.line({
     attributes: {
       class: 'lc-list-callout',
       style: `--lc-callout-color: ${color}`,
+      'data-type': `lc-${char}`,
     },
   });
 

--- a/src/postProcessor.ts
+++ b/src/postProcessor.ts
@@ -81,6 +81,7 @@ export function buildPostProcessor(
 
         if (match) {
           li.addClass('lc-list-callout');
+          li.setAttribute('data-type', "lc-" + callout.char);
           li.style.setProperty('--lc-callout-color', callout.color);
 
           node.replaceWith(


### PR DESCRIPTION
This PR adds data-type attributes in both Live Preview and Reading modes to help users customize the style of list callouts.

Resolves #24. 

I am probably under-thinking this, somehow, as it seemed too easy — but it worked to allow me to create some sidenote list-callouts! 

One possible problem this does not anticipate is the use of illegal characters in list callout characters. `callout.char` should probably be cleaned before using it in these ways, but I haven't yet figured out how to do that.